### PR TITLE
change bool to uint256

### DIFF
--- a/src/extensions/ERC721PartnerSeaDropRandomOffset.sol
+++ b/src/extensions/ERC721PartnerSeaDropRandomOffset.sol
@@ -19,7 +19,9 @@ contract ERC721PartnerSeaDropRandomOffset is ERC721PartnerSeaDrop {
 
     /// @notice If the collection has been revealed and the randomOffset has
     ///         been set.
-    bool public revealed;
+    uint256 public constant REVEALED_FALSE = 1;
+    uint256 public constant REVEALED_TRUE = 2;
+    uint256 public revealed = REVEALED_FALSE;
 
     /// @notice Revert when setting the randomOffset if already set.
     error AlreadyRevealed();
@@ -46,7 +48,7 @@ contract ERC721PartnerSeaDropRandomOffset is ERC721PartnerSeaDrop {
      *         reveal.
      */
     function setRandomOffset() external onlyOwner {
-        if (revealed) {
+        if (revealed == REVEALED_TRUE) {
             revert AlreadyRevealed();
         }
         if (_totalMinted() != _maxSupply) {
@@ -59,7 +61,7 @@ contract ERC721PartnerSeaDropRandomOffset is ERC721PartnerSeaDrop {
             (uint256(keccak256(abi.encode(block.difficulty))) %
                 (_maxSupply - 1)) +
             1;
-        revealed = true;
+        revealed = REVEALED_TRUE;
     }
 
     /**
@@ -82,7 +84,7 @@ contract ERC721PartnerSeaDropRandomOffset is ERC721PartnerSeaDrop {
         if (bytes(base).length == 0) {
             // If there is no baseURI set, return an empty string.
             return "";
-        } else if (!revealed) {
+        } else if (revealed == REVEALED_FALSE) {
             // If the baseURI is set but the collection is not revealed yet,
             // return just the baseURI.
             return base;


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Bools use 8 bit but they only need 1 bit. And it takes 20,000 gas to set a slot from zero to non-zero with SSTORE. So changing bool to uint can save a lot of gas.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution
Use uint256 instead of bool if this bool variable takes up an entire slot.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
