### PR TITLE
Add multiConfigure method to ERC721SeaDrop

### DIFF
--- a/src/ERC721ContractMetadata.sol
+++ b/src/ERC721ContractMetadata.sol
@@ -40,6 +40,16 @@ contract ERC721ContractMetadata is
     bytes32 _provenanceHash;
 
     /**
+     * @dev Throws if the sender is not the owner or the contract itself.
+     */
+    modifier onlyOwnerOrSelf() {
+        if (owner() != msg.sender && msg.sender != address(this)) {
+            revert OnlyOwner();
+        }
+        _;
+    }
+
+    /**
      * @notice Deploy the token contract with its name and symbol.
      */
     constructor(string memory name, string memory symbol)
@@ -68,7 +78,7 @@ contract ERC721ContractMetadata is
     function setContractURI(string calldata newContractURI)
         external
         override
-        onlyOwner
+        onlyOwnerOrSelf
     {
         // Set the new contract URI.
         _contractURI = newContractURI;
@@ -118,7 +128,10 @@ contract ERC721ContractMetadata is
      *
      * @param newProvenanceHash The new provenance hash to set.
      */
-    function setProvenanceHash(bytes32 newProvenanceHash) external onlyOwner {
+    function setProvenanceHash(bytes32 newProvenanceHash)
+        external
+        onlyOwnerOrSelf
+    {
         // Revert if any items have been minted.
         if (_totalMinted() > 0) {
             revert ProvenanceHashCannotBeSetAfterMintStarted();
@@ -139,7 +152,7 @@ contract ERC721ContractMetadata is
      *
      * @param newMaxSupply The new max supply to set.
      */
-    function setMaxSupply(uint256 newMaxSupply) external onlyOwner {
+    function setMaxSupply(uint256 newMaxSupply) external onlyOwnerOrSelf {
         // Ensure the max supply does not exceed the maximum value of uint64.
         if (newMaxSupply > 2**64 - 1) {
             revert CannotExceedMaxSupplyOfUint64(newMaxSupply);
@@ -160,7 +173,7 @@ contract ERC721ContractMetadata is
     function setBaseURI(string calldata newBaseURI)
         external
         override
-        onlyOwner
+        onlyOwnerOrSelf
     {
         // Set the new base URI.
         _tokenBaseURI = newBaseURI;

--- a/src/ERC721ContractMetadata.sol
+++ b/src/ERC721ContractMetadata.sol
@@ -43,7 +43,10 @@ contract ERC721ContractMetadata is
      * @dev Throws if the sender is not the owner or the contract itself.
      */
     modifier onlyOwnerOrSelf() {
-        if (owner() != msg.sender && msg.sender != address(this)) {
+        if (
+            _cast(msg.sender == owner()) | _cast(msg.sender == address(this)) ==
+            0
+        ) {
             revert OnlyOwner();
         }
         _;
@@ -188,5 +191,18 @@ contract ERC721ContractMetadata is
      */
     function _baseURI() internal view virtual override returns (string memory) {
         return _tokenBaseURI;
+    }
+
+    /**
+     * @dev Internal pure function to cast a `bool` value to a `uint256` value.
+     *
+     * @param b The `bool` value to cast.
+     *
+     * @return u The `uint256` value.
+     */
+    function _cast(bool b) internal pure returns (uint256 u) {
+        assembly {
+            u := b
+        }
     }
 }

--- a/src/ERC721SeaDrop.sol
+++ b/src/ERC721SeaDrop.sol
@@ -477,6 +477,12 @@ contract ERC721SeaDrop is
 
     /**
      * @notice Configure multiple properties at a time.
+     *
+     *         Note: The individual configure methods should be used
+     *         to unset or reset any properties to zero, as this method
+     *         will ignore zero-value properties in the config struct.
+     *
+     * @param config The configuration struct.
      */
     function multiConfigure(MultiConfigureStruct calldata config)
         external
@@ -510,12 +516,32 @@ contract ERC721SeaDrop is
                 config.creatorPayoutAddress
             );
         }
-        if (config.allowedFeeRecipient != address(0)) {
-            this.updateAllowedFeeRecipient(
-                config.seaDropImpl,
-                config.allowedFeeRecipient,
-                true
-            );
+        if (config.provenanceHash != bytes32(0)) {
+            this.setProvenanceHash(config.provenanceHash);
+        }
+        if (config.allowedFeeRecipients.length > 0) {
+            for (uint256 i = 0; i < config.allowedFeeRecipients.length; ) {
+                this.updateAllowedFeeRecipient(
+                    config.seaDropImpl,
+                    config.allowedFeeRecipients[i],
+                    true
+                );
+                unchecked {
+                    ++i;
+                }
+            }
+        }
+        if (config.disallowedFeeRecipients.length > 0) {
+            for (uint256 i = 0; i < config.disallowedFeeRecipients.length; ) {
+                this.updateAllowedFeeRecipient(
+                    config.seaDropImpl,
+                    config.disallowedFeeRecipients[i],
+                    false
+                );
+                unchecked {
+                    ++i;
+                }
+            }
         }
         if (config.allowedPayers.length > 0) {
             for (uint256 i = 0; i < config.allowedPayers.length; ) {
@@ -529,8 +555,17 @@ contract ERC721SeaDrop is
                 }
             }
         }
-        if (config.provenanceHash != bytes32(0)) {
-            this.setProvenanceHash(config.provenanceHash);
+        if (config.disallowedPayers.length > 0) {
+            for (uint256 i = 0; i < config.disallowedPayers.length; ) {
+                this.updatePayer(
+                    config.seaDropImpl,
+                    config.disallowedPayers[i],
+                    false
+                );
+                unchecked {
+                    ++i;
+                }
+            }
         }
         if (config.tokenGatedDropStages.length > 0) {
             if (
@@ -544,6 +579,23 @@ contract ERC721SeaDrop is
                     config.seaDropImpl,
                     config.tokenGatedAllowedNftTokens[i],
                     config.tokenGatedDropStages[i]
+                );
+                unchecked {
+                    ++i;
+                }
+            }
+        }
+        if (config.disallowedTokenGatedAllowedNftTokens.length > 0) {
+            for (
+                uint256 i = 0;
+                i < config.disallowedTokenGatedAllowedNftTokens.length;
+
+            ) {
+                TokenGatedDropStage memory emptyStage;
+                this.updateTokenGatedDrop(
+                    config.seaDropImpl,
+                    config.disallowedTokenGatedAllowedNftTokens[i],
+                    emptyStage
                 );
                 unchecked {
                     ++i;
@@ -566,6 +618,19 @@ contract ERC721SeaDrop is
                     config.seaDropImpl,
                     config.signers[i],
                     config.signedMintValidationParams[i]
+                );
+                unchecked {
+                    ++i;
+                }
+            }
+        }
+        if (config.disallowedSigners.length > 0) {
+            for (uint256 i = 0; i < config.disallowedSigners.length; ) {
+                SignedMintValidationParams memory emptyParams;
+                this.updateSignedMintValidationParams(
+                    config.seaDropImpl,
+                    config.disallowedSigners[i],
+                    emptyParams
                 );
                 unchecked {
                     ++i;

--- a/src/ERC721SeaDrop.sol
+++ b/src/ERC721SeaDrop.sol
@@ -19,6 +19,10 @@ import {
     SignedMintValidationParams
 } from "./lib/SeaDropStructs.sol";
 
+import {
+    ERC721SeaDropStructsErrorsAndEvents
+} from "./lib/ERC721SeaDropStructsErrorsAndEvents.sol";
+
 import { ERC721A } from "ERC721A/ERC721A.sol";
 
 import { ReentrancyGuard } from "solmate/utils/ReentrancyGuard.sol";
@@ -42,12 +46,10 @@ import {
 contract ERC721SeaDrop is
     ERC721ContractMetadata,
     INonFungibleSeaDropToken,
+    ERC721SeaDropStructsErrorsAndEvents,
     ReentrancyGuard,
     DefaultOperatorFilterer
 {
-    /// @notice Revert with an error if mint exceeds the max supply.
-    error MintQuantityExceedsMaxSupply(uint256 total, uint256 maxSupply);
-
     /// @notice Track the allowed SeaDrop addresses.
     mapping(address => bool) internal _allowedSeaDrop;
 
@@ -87,6 +89,9 @@ contract ERC721SeaDrop is
 
         // Set the enumeration.
         _enumeratedAllowedSeaDrop = allowedSeaDrop;
+
+        // Emit an event noting the contract deployment.
+        emit SeaDropTokenDeployed();
     }
 
     /**
@@ -201,7 +206,13 @@ contract ERC721SeaDrop is
     function updatePublicDrop(
         address seaDropImpl,
         PublicDrop calldata publicDrop
-    ) external virtual override onlyOwner onlyAllowedSeaDrop(seaDropImpl) {
+    )
+        external
+        virtual
+        override
+        onlyOwnerOrSelf
+        onlyAllowedSeaDrop(seaDropImpl)
+    {
         // Update the public drop data on SeaDrop.
         ISeaDrop(seaDropImpl).updatePublicDrop(publicDrop);
     }
@@ -216,7 +227,13 @@ contract ERC721SeaDrop is
     function updateAllowList(
         address seaDropImpl,
         AllowListData calldata allowListData
-    ) external virtual override onlyOwner onlyAllowedSeaDrop(seaDropImpl) {
+    )
+        external
+        virtual
+        override
+        onlyOwnerOrSelf
+        onlyAllowedSeaDrop(seaDropImpl)
+    {
         // Update the allow list on SeaDrop.
         ISeaDrop(seaDropImpl).updateAllowList(allowListData);
     }
@@ -241,7 +258,13 @@ contract ERC721SeaDrop is
         address seaDropImpl,
         address allowedNftToken,
         TokenGatedDropStage calldata dropStage
-    ) external virtual override onlyOwner onlyAllowedSeaDrop(seaDropImpl) {
+    )
+        external
+        virtual
+        override
+        onlyOwnerOrSelf
+        onlyAllowedSeaDrop(seaDropImpl)
+    {
         // Update the token gated drop stage.
         ISeaDrop(seaDropImpl).updateTokenGatedDrop(allowedNftToken, dropStage);
     }
@@ -257,7 +280,7 @@ contract ERC721SeaDrop is
         external
         virtual
         override
-        onlyOwner
+        onlyOwnerOrSelf
         onlyAllowedSeaDrop(seaDropImpl)
     {
         // Update the drop URI.
@@ -274,7 +297,7 @@ contract ERC721SeaDrop is
     function updateCreatorPayoutAddress(
         address seaDropImpl,
         address payoutAddress
-    ) external onlyOwner onlyAllowedSeaDrop(seaDropImpl) {
+    ) external onlyOwnerOrSelf onlyAllowedSeaDrop(seaDropImpl) {
         // Update the creator payout address.
         ISeaDrop(seaDropImpl).updateCreatorPayoutAddress(payoutAddress);
     }
@@ -292,7 +315,7 @@ contract ERC721SeaDrop is
         address seaDropImpl,
         address feeRecipient,
         bool allowed
-    ) external virtual onlyOwner onlyAllowedSeaDrop(seaDropImpl) {
+    ) external virtual onlyOwnerOrSelf onlyAllowedSeaDrop(seaDropImpl) {
         // Update the allowed fee recipient.
         ISeaDrop(seaDropImpl).updateAllowedFeeRecipient(feeRecipient, allowed);
     }
@@ -311,7 +334,13 @@ contract ERC721SeaDrop is
         address seaDropImpl,
         address signer,
         SignedMintValidationParams memory signedMintValidationParams
-    ) external virtual override onlyOwner onlyAllowedSeaDrop(seaDropImpl) {
+    )
+        external
+        virtual
+        override
+        onlyOwnerOrSelf
+        onlyAllowedSeaDrop(seaDropImpl)
+    {
         // Update the signer.
         ISeaDrop(seaDropImpl).updateSignedMintValidationParams(
             signer,
@@ -331,7 +360,13 @@ contract ERC721SeaDrop is
         address seaDropImpl,
         address payer,
         bool allowed
-    ) external virtual override onlyOwner onlyAllowedSeaDrop(seaDropImpl) {
+    )
+        external
+        virtual
+        override
+        onlyOwnerOrSelf
+        onlyAllowedSeaDrop(seaDropImpl)
+    {
         // Update the payer.
         ISeaDrop(seaDropImpl).updatePayer(payer, allowed);
     }
@@ -438,5 +473,102 @@ contract ERC721SeaDrop is
         bytes memory data
     ) public override onlyAllowedOperator(from) {
         super.safeTransferFrom(from, to, tokenId, data);
+    }
+
+    /**
+     * @notice Configure multiple properties at a time.
+     */
+    function multiConfigure(MultiConfigureStruct calldata config)
+        external
+        onlyOwner
+    {
+        if (config.maxSupply > 0) {
+            this.setMaxSupply(config.maxSupply);
+        }
+        if (bytes(config.baseURI).length != 0) {
+            this.setBaseURI(config.baseURI);
+        }
+        if (bytes(config.contractURI).length != 0) {
+            this.setContractURI(config.contractURI);
+        }
+        if (
+            config.publicDrop.startTime != 0 && config.publicDrop.endTime != 0
+        ) {
+            this.updatePublicDrop(config.seaDropImpl, config.publicDrop);
+        }
+        if (bytes(config.dropURI).length != 0) {
+            this.updateDropURI(config.seaDropImpl, config.dropURI);
+        }
+        if (config.allowListData.merkleRoot != bytes32(0)) {
+            this.updateAllowList(config.seaDropImpl, config.allowListData);
+        }
+        if (config.creatorPayoutAddress != address(0)) {
+            this.updateCreatorPayoutAddress(
+                config.seaDropImpl,
+                config.creatorPayoutAddress
+            );
+        }
+        if (config.allowedFeeRecipient != address(0)) {
+            this.updateAllowedFeeRecipient(
+                config.seaDropImpl,
+                config.allowedFeeRecipient,
+                true
+            );
+        }
+        if (config.allowedPayers.length > 0) {
+            for (uint256 i = 0; i < config.allowedPayers.length; ) {
+                this.updatePayer(
+                    config.seaDropImpl,
+                    config.allowedPayers[i],
+                    true
+                );
+                unchecked {
+                    ++i;
+                }
+            }
+        }
+        if (config.provenanceHash != bytes32(0)) {
+            this.setProvenanceHash(config.provenanceHash);
+        }
+        if (config.tokenGatedDropStages.length > 0) {
+            if (
+                config.tokenGatedDropStages.length !=
+                config.tokenGatedAllowedNftTokens.length
+            ) {
+                revert TokenGatedMismatch();
+            }
+            for (uint256 i = 0; i < config.tokenGatedDropStages.length; ) {
+                this.updateTokenGatedDrop(
+                    config.seaDropImpl,
+                    config.tokenGatedAllowedNftTokens[i],
+                    config.tokenGatedDropStages[i]
+                );
+                unchecked {
+                    ++i;
+                }
+            }
+        }
+        if (config.signedMintValidationParams.length > 0) {
+            if (
+                config.signedMintValidationParams.length !=
+                config.signers.length
+            ) {
+                revert SignersMismatch();
+            }
+            for (
+                uint256 i = 0;
+                i < config.signedMintValidationParams.length;
+
+            ) {
+                this.updateSignedMintValidationParams(
+                    config.seaDropImpl,
+                    config.signers[i],
+                    config.signedMintValidationParams[i]
+                );
+                unchecked {
+                    ++i;
+                }
+            }
+        }
     }
 }

--- a/src/ERC721SeaDrop.sol
+++ b/src/ERC721SeaDrop.sol
@@ -492,7 +492,9 @@ contract ERC721SeaDrop is
             this.setContractURI(config.contractURI);
         }
         if (
-            config.publicDrop.startTime != 0 && config.publicDrop.endTime != 0
+            _cast(config.publicDrop.startTime != 0) |
+                _cast(config.publicDrop.endTime != 0) ==
+            1
         ) {
             this.updatePublicDrop(config.seaDropImpl, config.publicDrop);
         }

--- a/src/SeaDrop.sol
+++ b/src/SeaDrop.sol
@@ -603,7 +603,11 @@ contract SeaDrop is ISeaDrop, ReentrancyGuard {
      * @param endTime   The drop stage end time.
      */
     function _checkActive(uint256 startTime, uint256 endTime) internal view {
-        if (block.timestamp < startTime || block.timestamp > endTime) {
+        if (
+            _cast(block.timestamp < startTime) |
+                _cast(block.timestamp > endTime) ==
+            1
+        ) {
             // Revert if the drop stage is not active.
             revert NotActive(block.timestamp, startTime, endTime);
         }
@@ -1371,5 +1375,18 @@ contract SeaDrop is ISeaDrop, ReentrancyGuard {
                 )
             )
         );
+    }
+
+    /**
+     * @dev Internal pure function to cast a `bool` value to a `uint256` value.
+     *
+     * @param b The `bool` value to cast.
+     *
+     * @return u The `uint256` value.
+     */
+    function _cast(bool b) internal pure returns (uint256 u) {
+        assembly {
+            u := b
+        }
     }
 }

--- a/src/lib/ERC721SeaDropStructsErrorsAndEvents.sol
+++ b/src/lib/ERC721SeaDropStructsErrorsAndEvents.sol
@@ -33,7 +33,7 @@ interface ERC721SeaDropStructsErrorsAndEvents {
   event SeaDropTokenDeployed();
 
   /**
-   * @notice A struct to configure multiple options at a time.
+   * @notice A struct to configure multiple contract options at a time.
    */
   struct MultiConfigureStruct {
     uint256 maxSupply;
@@ -44,16 +44,22 @@ interface ERC721SeaDropStructsErrorsAndEvents {
     string dropURI;
     AllowListData allowListData;
     address creatorPayoutAddress;
-    address allowedFeeRecipient;
     bytes32 provenanceHash;
+
+    address[] allowedFeeRecipients;
+    address[] disallowedFeeRecipients;
+
     address[] allowedPayers;
+    address[] disallowedPayers;
 
     // Token-gated
     address[] tokenGatedAllowedNftTokens;
     TokenGatedDropStage[] tokenGatedDropStages;
+    address[] disallowedTokenGatedAllowedNftTokens;
 
     // Server-signed
     address[] signers;
     SignedMintValidationParams[] signedMintValidationParams;
+    address[] disallowedSigners;
   }
 }

--- a/src/lib/ERC721SeaDropStructsErrorsAndEvents.sol
+++ b/src/lib/ERC721SeaDropStructsErrorsAndEvents.sol
@@ -9,22 +9,32 @@ import {
 } from "./SeaDropStructs.sol";
 
 interface ERC721SeaDropStructsErrorsAndEvents {
-  /// @notice Revert with an error if mint exceeds the max supply.
+  /**
+   * @notice Revert with an error if mint exceeds the max supply.
+   */
   error MintQuantityExceedsMaxSupply(uint256 total, uint256 maxSupply);
 
-  /// @notice Revert with an error if the number of token gated 
-  ///         allowedNftTokens doesn't match the length of supplied
-  ///         drop stages.
+  /**
+   * @notice Revert with an error if the number of token gated 
+   *         allowedNftTokens doesn't match the length of supplied
+   *         drop stages.
+   */
   error TokenGatedMismatch();
 
-  /// @notice Revert with an error if the number of signers doesn't match
-  ///         the length of supplied signedMintValidationParams
+  /**
+   *  @notice Revert with an error if the number of signers doesn't match
+   *          the length of supplied signedMintValidationParams
+   */
   error SignersMismatch();
 
-  /// @notice An event to signify that a SeaDrop token contract was deployed.
+  /**
+   * @notice An event to signify that a SeaDrop token contract was deployed.
+   */
   event SeaDropTokenDeployed();
 
-  /// @notice A struct to configure multiple options at a time.
+  /**
+   * @notice A struct to configure multiple options at a time.
+   */
   struct MultiConfigureStruct {
     uint256 maxSupply;
     string baseURI;
@@ -38,9 +48,11 @@ interface ERC721SeaDropStructsErrorsAndEvents {
     bytes32 provenanceHash;
     address[] allowedPayers;
 
+    // Token-gated
     address[] tokenGatedAllowedNftTokens;
     TokenGatedDropStage[] tokenGatedDropStages;
 
+    // Server-signed
     address[] signers;
     SignedMintValidationParams[] signedMintValidationParams;
   }

--- a/src/lib/ERC721SeaDropStructsErrorsAndEvents.sol
+++ b/src/lib/ERC721SeaDropStructsErrorsAndEvents.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {
+  AllowListData,
+  PublicDrop,
+  SignedMintValidationParams,
+  TokenGatedDropStage
+} from "./SeaDropStructs.sol";
+
+interface ERC721SeaDropStructsErrorsAndEvents {
+  /// @notice Revert with an error if mint exceeds the max supply.
+  error MintQuantityExceedsMaxSupply(uint256 total, uint256 maxSupply);
+
+  /// @notice Revert with an error if the number of token gated 
+  ///         allowedNftTokens doesn't match the length of supplied
+  ///         drop stages.
+  error TokenGatedMismatch();
+
+  /// @notice Revert with an error if the number of signers doesn't match
+  ///         the length of supplied signedMintValidationParams
+  error SignersMismatch();
+
+  /// @notice An event to signify that a SeaDrop token contract was deployed.
+  event SeaDropTokenDeployed();
+
+  /// @notice A struct to configure multiple options at a time.
+  struct MultiConfigureStruct {
+    uint256 maxSupply;
+    string baseURI;
+    string contractURI;
+    address seaDropImpl;
+    PublicDrop publicDrop;
+    string dropURI;
+    AllowListData allowListData;
+    address creatorPayoutAddress;
+    address allowedFeeRecipient;
+    bytes32 provenanceHash;
+    address[] allowedPayers;
+
+    address[] tokenGatedAllowedNftTokens;
+    TokenGatedDropStage[] tokenGatedDropStages;
+
+    address[] signers;
+    SignedMintValidationParams[] signedMintValidationParams;
+  }
+}


### PR DESCRIPTION
- Adds a `multiConfigure` method to ERC721SeaDrop to make it easier to configure the contract in one transaction.
- Adds a `SeaDropTokenDeployed` event to make it easier to note a new SeaDrop token contract is deployed.