### PR TITLE
Add non-partner extension contracts

### DIFF
--- a/docs/SeaDropTokenDeployment.md
+++ b/docs/SeaDropTokenDeployment.md
@@ -67,7 +67,6 @@ Follows the pattern of `tokenURI` — could be either on-chain data blob or exte
       "name": "My Public Stage",
       "description": "My public stage description.",
       "uuid": "ecae5ad4-fa40-4e79-856b-ec304c3ea5d4",
-      "promoImage": "https://google.com/123.png",
       "isPublic": true,
       "mintPrice": 1000000000000000000,
       "maxTotalMintableByWallet": 50,
@@ -80,7 +79,6 @@ Follows the pattern of `tokenURI` — could be either on-chain data blob or exte
       "name": "My Private Allow List Stage",
       "description": "My private stage description",
       "uuid": "07e7a791-42ad-46e6-968a-564acf0c06dc",
-      "promoImage": "https://google.com/456.png",
       "isPublic": false,
       "mintPrice": 1000000000000000,
       "maxTotalMintableByWallet": 5,
@@ -118,9 +116,6 @@ Follows the pattern of `tokenURI` — could be either on-chain data blob or exte
             "type": "string"
           },
           "uuid": {
-            "type": "string"
-          },
-          "promoImage": {
             "type": "string"
           },
           "isPublic": {

--- a/src/extensions/ERC721SeaDropBurnable.sol
+++ b/src/extensions/ERC721SeaDropBurnable.sol
@@ -12,7 +12,7 @@ import { ERC721SeaDrop } from "../ERC721SeaDrop.sol";
  * @notice ERC721SeaDropBurnable is a token contract that extends
  *         ERC721SeaDrop to additionally provide a burn function.
  */
-contract ERC721ERC721SeaDropSeaDropBurnable is ERC721SeaDrop {
+contract ERC721SeaDropBurnable is ERC721SeaDrop {
     /**
      * @notice Deploy the token contract with its name, symbol,
      *         and allowed SeaDrop addresses.

--- a/src/extensions/ERC721SeaDropBurnable.sol
+++ b/src/extensions/ERC721SeaDropBurnable.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import { ERC721SeaDrop } from "../ERC721SeaDrop.sol";
+
+/**
+ * @title  ERC721SeaDropBurnable
+ * @author James Wenzel (emo.eth)
+ * @author Ryan Ghods (ralxz.eth)
+ * @author Stephan Min (stephanm.eth)
+ * @author Michael Cohen (notmichael.eth)
+ * @notice ERC721SeaDropBurnable is a token contract that extends
+ *         ERC721SeaDrop to additionally provide a burn function.
+ */
+contract ERC721ERC721SeaDropSeaDropBurnable is ERC721SeaDrop {
+    /**
+     * @notice Deploy the token contract with its name, symbol,
+     *         and allowed SeaDrop addresses.
+     */
+    constructor(
+        string memory name,
+        string memory symbol,
+        address[] memory allowedSeaDrop
+    ) ERC721SeaDrop(name, symbol, allowedSeaDrop) {}
+
+    /**
+     * @notice Burns `tokenId`. The caller must own `tokenId` or be an
+     *         approved operator.
+     *
+     * @param tokenId The token id to burn.
+     */
+    // solhint-disable-next-line comprehensive-interface
+    function burn(uint256 tokenId) external {
+        _burn(tokenId, true);
+    }
+}

--- a/src/extensions/ERC721SeaDropRandomOffset.sol
+++ b/src/extensions/ERC721SeaDropRandomOffset.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import { ERC721SeaDrop } from "../ERC721SeaDrop.sol";
+
+/**
+ * @title  ERC721SeaDropRandomOffset
+ * @author James Wenzel (emo.eth)
+ * @author Ryan Ghods (ralxz.eth)
+ * @author Stephan Min (stephanm.eth)
+ * @author Michael Cohen (notmichael.eth)
+ * @notice ERC721SeaDropRandomOffset is a token contract that extends
+ *         ERC721SeaDrop to apply a randomOffset to the tokenURI,
+ *         to enable fair metadata reveals.
+ */
+contract ERC721SeaDropRandomOffset is ERC721SeaDrop {
+    /// @notice The random offset, between 1 and the MAX_SUPPLY at the time of
+    ///         being set.
+    uint256 public randomOffset;
+
+    /// @notice If the collection has been revealed and the randomOffset has
+    ///         been set. 1=False, 2=True.
+    uint256 public revealed = _REVEALED_FALSE;
+
+    /// @dev For gas efficiency, uint is used instead of bool for revealed.
+    uint256 private constant _REVEALED_FALSE = 1;
+    uint256 private constant _REVEALED_TRUE = 2;
+
+    /// @notice Revert when setting the randomOffset if already set.
+    error AlreadyRevealed();
+
+    /// @notice Revert when setting the randomOffset if the collection is
+    ///         not yet fully minted.
+    error NotFullyMinted();
+
+    /**
+     * @notice Deploy the token contract with its name, symbol,
+     *         and allowed SeaDrop addresses.
+     */
+    constructor(
+        string memory name,
+        string memory symbol,
+        address[] memory allowedSeaDrop
+    ) ERC721SeaDrop(name, symbol, allowedSeaDrop) {}
+
+    /**
+     * @notice Set the random offset, for a fair metadata reveal. Only callable
+     *         by the owner one time when the total number of minted tokens
+     *         equals the max supply. Should be called immediately before
+     *         reveal.
+     */
+    // solhint-disable-next-line comprehensive-interface
+    function setRandomOffset() external onlyOwner {
+        // Revert setting the offset if already revealed.
+        if (revealed == _REVEALED_TRUE) {
+            revert AlreadyRevealed();
+        }
+
+        // Put maxSupply on the stack, since reading a state variable
+        // costs more gas than reading a local variable.
+        uint256 maxSupply = _maxSupply;
+
+        // Revert if the collection is not yet fully minted.
+        if (_totalMinted() != maxSupply) {
+            revert NotFullyMinted();
+        }
+
+        // block.difficulty returns PREVRANDAO on Ethereum post-merge
+        // NOTE: do not use this on other chains
+        // randomOffset returns between 1 and MAX_SUPPLY
+        randomOffset =
+            (uint256(keccak256(abi.encode(block.difficulty))) %
+                (maxSupply - 1)) +
+            1;
+
+        // Set revealed to true.
+        revealed = _REVEALED_TRUE;
+    }
+
+    /**
+     * @notice The token URI, offset by randomOffset, to enable fair metadata
+     *         reveals.
+     *
+     * @param tokenId The token id
+     */
+    function tokenURI(uint256 tokenId)
+        public
+        view
+        override
+        returns (string memory)
+    {
+        if (!_exists(tokenId)) {
+            revert URIQueryForNonexistentToken();
+        }
+
+        string memory base = _baseURI();
+        if (bytes(base).length == 0) {
+            // If there is no baseURI set, return an empty string.
+            return "";
+        } else if (revealed == _REVEALED_FALSE) {
+            // If the baseURI is set but the collection is not revealed yet,
+            // return just the baseURI.
+            return base;
+        } else {
+            // If the baseURI is set and the collection is revealed,
+            // return the tokenURI offset by the randomOffset.
+            return
+                string.concat(
+                    base,
+                    _toString(
+                        ((tokenId + randomOffset) % _maxSupply) +
+                            _startTokenId()
+                    )
+                );
+        }
+    }
+}

--- a/test/ERC721SeaDropBurnable.spec.ts
+++ b/test/ERC721SeaDropBurnable.spec.ts
@@ -6,10 +6,7 @@ import { faucet } from "./utils/faucet";
 import { VERSION } from "./utils/helpers";
 import { whileImpersonating } from "./utils/impersonate";
 
-import type {
-  ERC721SeaDropBurnable,
-  ISeaDrop,
-} from "../typechain-types";
+import type { ERC721SeaDropBurnable, ISeaDrop } from "../typechain-types";
 import type { Wallet } from "ethers";
 
 describe(`ERC721SeaDropBurnable (v${VERSION})`, function () {
@@ -50,9 +47,7 @@ describe(`ERC721SeaDropBurnable (v${VERSION})`, function () {
       "ERC721SeaDropBurnable",
       owner
     );
-    token = await ERC721SeaDropBurnable.deploy("", "", [
-      seadrop.address,
-    ]);
+    token = await ERC721SeaDropBurnable.deploy("", "", [seadrop.address]);
   });
 
   it("Should only let the token owner burn their own token", async () => {

--- a/test/ERC721SeaDropBurnable.spec.ts
+++ b/test/ERC721SeaDropBurnable.spec.ts
@@ -1,0 +1,128 @@
+import { expect } from "chai";
+import { ethers, network } from "hardhat";
+
+import { randomHex } from "./utils/encoding";
+import { faucet } from "./utils/faucet";
+import { VERSION } from "./utils/helpers";
+import { whileImpersonating } from "./utils/impersonate";
+
+import type {
+  ERC721SeaDropBurnable,
+  ISeaDrop,
+} from "../typechain-types";
+import type { Wallet } from "ethers";
+
+describe(`ERC721SeaDropBurnable (v${VERSION})`, function () {
+  const { provider } = ethers;
+  let seadrop: ISeaDrop;
+  let token: ERC721SeaDropBurnable;
+  let owner: Wallet;
+  let creator: Wallet;
+  let minter: Wallet;
+  let approved: Wallet;
+
+  after(async () => {
+    await network.provider.request({
+      method: "hardhat_reset",
+    });
+  });
+
+  before(async () => {
+    // Set the wallets
+    owner = new ethers.Wallet(randomHex(32), provider);
+    creator = new ethers.Wallet(randomHex(32), provider);
+    minter = new ethers.Wallet(randomHex(32), provider);
+    approved = new ethers.Wallet(randomHex(32), provider);
+
+    // Add eth to wallets
+    for (const wallet of [owner, minter, creator, approved]) {
+      await faucet(wallet.address, provider);
+    }
+
+    // Deploy SeaDrop
+    const SeaDrop = await ethers.getContractFactory("SeaDrop", owner);
+    seadrop = await SeaDrop.deploy();
+  });
+
+  beforeEach(async () => {
+    // Deploy token
+    const ERC721SeaDropBurnable = await ethers.getContractFactory(
+      "ERC721SeaDropBurnable",
+      owner
+    );
+    token = await ERC721SeaDropBurnable.deploy("", "", [
+      seadrop.address,
+    ]);
+  });
+
+  it("Should only let the token owner burn their own token", async () => {
+    await token.setMaxSupply(3);
+
+    // Mint three tokens to the minter.
+    await whileImpersonating(
+      seadrop.address,
+      provider,
+      async (impersonatedSigner) => {
+        await token.connect(impersonatedSigner).mintSeaDrop(minter.address, 3);
+      }
+    );
+
+    expect(await token.ownerOf(1)).to.equal(minter.address);
+    expect(await token.ownerOf(2)).to.equal(minter.address);
+    expect(await token.ownerOf(3)).to.equal(minter.address);
+    expect(await token.totalSupply()).to.equal(3);
+
+    // Only the owner or approved of the minted token should be able to burn it.
+    await expect(token.connect(owner).burn(1)).to.be.revertedWith(
+      "TransferCallerNotOwnerNorApproved()"
+    );
+    await expect(token.connect(approved).burn(1)).to.be.revertedWith(
+      "TransferCallerNotOwnerNorApproved()"
+    );
+    await expect(token.connect(approved).burn(2)).to.be.revertedWith(
+      "TransferCallerNotOwnerNorApproved()"
+    );
+    await expect(token.connect(owner).burn(3)).to.be.revertedWith(
+      "TransferCallerNotOwnerNorApproved()"
+    );
+
+    expect(await token.ownerOf(1)).to.equal(minter.address);
+    expect(await token.ownerOf(2)).to.equal(minter.address);
+    expect(await token.ownerOf(3)).to.equal(minter.address);
+    expect(await token.totalSupply()).to.equal(3);
+
+    await token.connect(minter).burn(1);
+
+    expect(await token.totalSupply()).to.equal(2);
+
+    await token.connect(minter).setApprovalForAll(approved.address, true);
+    await token.connect(approved).burn(2);
+
+    expect(await token.totalSupply()).to.equal(1);
+
+    await token.connect(minter).setApprovalForAll(approved.address, false);
+    await expect(token.connect(approved).burn(3)).to.be.revertedWith(
+      "TransferCallerNotOwnerNorApproved()"
+    );
+
+    await token.connect(minter).approve(owner.address, 3);
+    await token.connect(owner).burn(3);
+
+    expect(await token.totalSupply()).to.equal(0);
+
+    await expect(token.ownerOf(1)).to.be.revertedWith(
+      "OwnerQueryForNonexistentToken()"
+    );
+    await expect(token.ownerOf(2)).to.be.revertedWith(
+      "OwnerQueryForNonexistentToken()"
+    );
+    expect(await token.totalSupply()).to.equal(0);
+
+    // Should not be able to burn a nonexistent token.
+    for (const tokenId of [0, 1, 2, 3]) {
+      await expect(token.connect(minter).burn(tokenId)).to.be.revertedWith(
+        "OwnerQueryForNonexistentToken()"
+      );
+    }
+  });
+});

--- a/test/ERC721SeaDropRandomOffset.spec.ts
+++ b/test/ERC721SeaDropRandomOffset.spec.ts
@@ -1,0 +1,138 @@
+import { expect } from "chai";
+import { ethers, network } from "hardhat";
+
+import { randomHex } from "./utils/encoding";
+import { faucet } from "./utils/faucet";
+import { VERSION } from "./utils/helpers";
+import { whileImpersonating } from "./utils/impersonate";
+
+import type {
+  ERC721SeaDropRandomOffset,
+  ISeaDrop,
+} from "../typechain-types";
+import type { Wallet } from "ethers";
+
+describe(`ERC721SeaDropRandomOffset (v${VERSION})`, function () {
+  const { provider } = ethers;
+  let seadrop: ISeaDrop;
+  let token: ERC721SeaDropRandomOffset;
+  let owner: Wallet;
+  let creator: Wallet;
+  let minter: Wallet;
+
+  after(async () => {
+    await network.provider.request({
+      method: "hardhat_reset",
+    });
+  });
+
+  before(async () => {
+    // Set the wallets
+    owner = new ethers.Wallet(randomHex(32), provider);
+    creator = new ethers.Wallet(randomHex(32), provider);
+    minter = new ethers.Wallet(randomHex(32), provider);
+
+    // Add eth to wallets
+    for (const wallet of [owner, minter, creator]) {
+      await faucet(wallet.address, provider);
+    }
+
+    // Deploy SeaDrop
+    const SeaDrop = await ethers.getContractFactory("SeaDrop", owner);
+    seadrop = await SeaDrop.deploy();
+  });
+
+  beforeEach(async () => {
+    // Deploy token
+    const ERC721SeaDropRandomOffset = await ethers.getContractFactory(
+      "ERC721SeaDropRandomOffset",
+      owner
+    );
+    token = await ERC721SeaDropRandomOffset.deploy(
+      "",
+      "",
+      [seadrop.address]
+    );
+  });
+
+  it("Should only let the owner call setRandomOffset once the max supply is reached", async () => {
+    await token.setMaxSupply(100);
+
+    await expect(token.connect(owner).setRandomOffset()).to.be.revertedWith(
+      "NotFullyMinted()"
+    );
+
+    // Mint to the max supply.
+    await whileImpersonating(
+      seadrop.address,
+      provider,
+      async (impersonatedSigner) => {
+        await token
+          .connect(impersonatedSigner)
+          .mintSeaDrop(minter.address, 100);
+      }
+    );
+
+    expect(await token.randomOffset()).to.equal(ethers.constants.Zero);
+
+    await token.connect(owner).setRandomOffset();
+
+    await expect(token.connect(owner).setRandomOffset()).to.be.revertedWith(
+      "AlreadyRevealed()"
+    );
+
+    expect(await token.randomOffset()).to.not.equal(ethers.constants.Zero);
+  });
+
+  it("Should return the tokenURI correctly offset by randomOffset", async () => {
+    await token.setMaxSupply(100);
+
+    await expect(token.tokenURI(1)).to.be.revertedWith(
+      "URIQueryForNonexistentToken()"
+    );
+
+    // Mint to the max supply.
+    await whileImpersonating(
+      seadrop.address,
+      provider,
+      async (impersonatedSigner) => {
+        await token
+          .connect(impersonatedSigner)
+          .mintSeaDrop(minter.address, 100);
+      }
+    );
+
+    expect(await token.tokenURI(1)).to.equal("");
+
+    await token.setBaseURI("http://example.com/");
+
+    expect(await token.tokenURI(1)).to.equal("http://example.com/");
+
+    await token.connect(owner).setRandomOffset();
+
+    const randomOffset = (await token.randomOffset()).toNumber();
+
+    expect(randomOffset).to.be.greaterThan(0);
+    expect(randomOffset).to.be.lessThanOrEqual(100);
+
+    const startTokenId = 1;
+
+    expect(await token.tokenURI(1)).to.equal(
+      `http://example.com/${((1 + randomOffset) % 100) + startTokenId}`
+    );
+    expect(await token.tokenURI(100)).to.equal(
+      `http://example.com/${((100 + randomOffset) % 100) + startTokenId}`
+    );
+
+    const tokenUri2 = 101 - randomOffset;
+    const tokenUri1 = 100 - randomOffset;
+    const tokenUri100 = 99 - randomOffset;
+    const tokenUri99 = 98 - randomOffset;
+    expect(await token.tokenURI(tokenUri2)).to.equal(`http://example.com/2`);
+    expect(await token.tokenURI(tokenUri1)).to.equal(`http://example.com/1`);
+    expect(await token.tokenURI(tokenUri100)).to.equal(
+      `http://example.com/100`
+    );
+    expect(await token.tokenURI(tokenUri99)).to.equal(`http://example.com/99`);
+  });
+});

--- a/test/ERC721SeaDropRandomOffset.spec.ts
+++ b/test/ERC721SeaDropRandomOffset.spec.ts
@@ -6,10 +6,7 @@ import { faucet } from "./utils/faucet";
 import { VERSION } from "./utils/helpers";
 import { whileImpersonating } from "./utils/impersonate";
 
-import type {
-  ERC721SeaDropRandomOffset,
-  ISeaDrop,
-} from "../typechain-types";
+import type { ERC721SeaDropRandomOffset, ISeaDrop } from "../typechain-types";
 import type { Wallet } from "ethers";
 
 describe(`ERC721SeaDropRandomOffset (v${VERSION})`, function () {
@@ -48,11 +45,7 @@ describe(`ERC721SeaDropRandomOffset (v${VERSION})`, function () {
       "ERC721SeaDropRandomOffset",
       owner
     );
-    token = await ERC721SeaDropRandomOffset.deploy(
-      "",
-      "",
-      [seadrop.address]
-    );
+    token = await ERC721SeaDropRandomOffset.deploy("", "", [seadrop.address]);
   });
 
   it("Should only let the owner call setRandomOffset once the max supply is reached", async () => {


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

As we extend the capabilities of OpenSea's Drops program to a wider audience, we would like to offer developers the ability to integrate with SeaDrop without having to rely on a direct partnership with OpenSea. Some of these developers might want a Burn or RandomOffset extension of `ERC721SeaDrop` that does not require an `administrator` role

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution
Implement `ERC721SeaDropBurnable` and `ERC721SeaDropRandomOffset` as direct extensions of `ERC721SeaDrop`. This PR also includes a minor revision to our DropURI schema that removes the `promoImage` field, which we do not use in our product.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
