### PR TITLE
Fixed ERC721SeaDropRandomOffset randomOffset

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -44,6 +44,7 @@ const config: HardhatUserConfig = {
     hardhat: {
       blockGasLimit: 30_000_000,
       throwOnCallFailures: false,
+      hardfork: "merge",
     },
     verificationNetwork: {
       url: process.env.NETWORK_RPC ?? "",

--- a/src/extensions/ERC721SeaDropRandomOffset.sol
+++ b/src/extensions/ERC721SeaDropRandomOffset.sol
@@ -67,11 +67,10 @@ contract ERC721SeaDropRandomOffset is ERC721SeaDrop {
 
         // block.difficulty returns PREVRANDAO on Ethereum post-merge
         // NOTE: do not use this on other chains
-        // randomOffset returns between 1 and MAX_SUPPLY
-        randomOffset =
-            (uint256(keccak256(abi.encode(block.difficulty))) %
-                (maxSupply - 1)) +
-            1;
+        // randomOffset returns between 0 and MAX_SUPPLY - 1
+        randomOffset = uint256(
+            keccak256(abi.encode(block.difficulty))
+        ) % maxSupply;
 
         // Set revealed to true.
         revealed = _REVEALED_TRUE;

--- a/test/utils/prevrandao.ts
+++ b/test/utils/prevrandao.ts
@@ -1,0 +1,27 @@
+import { BigNumber, ethers } from "ethers";
+
+import type { JsonRpcProvider } from "@ethersproject/providers";
+
+export const getPrevRandaoForOffset = (
+  targetOffset: number,
+  maxSupply: number
+) => {
+  let i = 0;
+  while (true) {
+    // Feels like proof-of-work all over again
+    const hash = ethers.utils.solidityKeccak256(
+      ["bytes"],
+      [ethers.utils.defaultAbiCoder.encode(["uint256"], [i])]
+    );
+    const offset = BigNumber.from(hash).mod(maxSupply).toNumber();
+    if (offset === targetOffset) {
+      return i;
+    }
+    i++;
+  }
+};
+
+export const setPrevRandao = (n: number, provider: JsonRpcProvider) => {
+  const prevRandao = `0x${n.toString(16).padStart(64, "0")}`;
+  return provider.send("hardhat_setPrevRandao", [prevRandao]);
+};


### PR DESCRIPTION
## Motivation

Just fixing an error that I noticed while browsing the code (reported issue #45): In the current code, when offsetting the token Ids with a random offset to shuffle the metadata, there are `maxSupply - 1` possibilities. There should be `maxSupply` possibility. After picking a fair random number, it should be perfectly possible that the outcome is: no offset

## Solution

Updated the randomOffset generation to make it perfectly capable of offsetting by zero if that's what the random number decided, accidentally saving some gas on the way. Also added the unit test that fails in the previous codebase and succeeds with this PR.

Closes #45