### PR TITLE
Changed optimizer runs to "1" and achieved drastically better performances

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -35,7 +35,7 @@ const config: HardhatUserConfig = {
           viaIR: false,
           optimizer: {
             enabled: true,
-            runs: 1_000_000,
+            runs: 1,
           },
         },
       },

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -8,6 +8,7 @@ import "@nomiclabs/hardhat-waffle";
 import "@nomiclabs/hardhat-etherscan";
 import "@typechain/hardhat";
 import "hardhat-gas-reporter";
+import "hardhat-contract-sizer";
 import "hardhat-preprocessor";
 
 // Configure remappings.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   },
   "dependencies": {
     "ethers": "^5.7.0",
-    "hardhat": "^2.11.1"
+    "hardhat": "^2.11.1",
+    "hardhat-contract-sizer": "^2.8.0"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
   },
   "dependencies": {
     "ethers": "^5.7.0",
-    "hardhat": "^2.11.1",
-    "hardhat-contract-sizer": "^2.8.0"
+    "hardhat": "^2.11.1"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.1.1",
@@ -54,6 +53,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.0.1",
     "ethereum-waffle": "^3.4.4",
+    "hardhat-contract-sizer": "^2.8.0",
     "hardhat-gas-reporter": "^1.0.9",
     "hardhat-preprocessor": "^0.1.5",
     "husky": "^8.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,11 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@colors/colors@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
+  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
@@ -2822,6 +2827,15 @@ cli-table3@^0.5.0:
   optionalDependencies:
     colors "^1.1.2"
 
+cli-table3@^0.6.0:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.3.tgz#61ab765aac156b52f222954ffc607a6f01dbeeb2"
+  integrity sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==
+  dependencies:
+    string-width "^4.2.0"
+  optionalDependencies:
+    "@colors/colors" "1.5.0"
+
 cli-truncate@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7"
@@ -5332,6 +5346,15 @@ har-validator@~5.1.3:
   dependencies:
     ajv "^6.12.3"
     har-schema "^2.0.0"
+
+hardhat-contract-sizer@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/hardhat-contract-sizer/-/hardhat-contract-sizer-2.8.0.tgz#730a9bf35ed200ba57b6865bd3f459a91c90f205"
+  integrity sha512-jXt2Si3uIDx5z99J+gvKa0yvIw156pE4dpH9X/PvTQv652BUd+qGj7WT93PXnHXGh5qhQLkjDYeZMYNOThfjFg==
+  dependencies:
+    chalk "^4.0.0"
+    cli-table3 "^0.6.0"
+    strip-ansi "^6.0.0"
 
 hardhat-gas-reporter@^1.0.9:
   version "1.0.9"


### PR DESCRIPTION
## Motivation

I originally wanted to use SeaDrop in a contract in a fresh hardhat installation then noticed it doesn't deploy without the optimizer (SeaDrop.sol was exceeding 31kb in size). I then added the optimizer option to my hardhat config with 1_000_000 runs and saw that the size was now much better (~ 20k). Thinking a million runs may be a bit overkill for just running some tests, I took that number down to 1000 and saw that the results were much better (~ 17k). I kept trying different values until I thought I had reached an optimal one with a single run: (~ 15k).

And it's not just SeaDrop. All the contracts are positively impacted

## Solution

Use the following configuration for the optimizer

```js
{
  optimizer: {
    enabled: true,
    runs: 1,
  }
}
```

Closes #48 