### PR TITLE
Override ERC721SeaDrop's tokenURI to make it easier to handle uniform tokenURIs

### DIFF
--- a/src/ERC721SeaDrop.sol
+++ b/src/ERC721SeaDrop.sol
@@ -40,6 +40,7 @@ import {
  * @author James Wenzel (emo.eth)
  * @author Ryan Ghods (ralxz.eth)
  * @author Stephan Min (stephanm.eth)
+ * @author Michael Cohen (notmichael.eth)
  * @notice ERC721SeaDrop is a token contract that contains methods
  *         to properly interact with SeaDrop.
  */
@@ -154,6 +155,31 @@ contract ERC721SeaDrop is
      */
     function _startTokenId() internal view virtual override returns (uint256) {
         return 1;
+    }
+
+    /**
+     * @dev Overrides the `tokenURI()` function from ERC721A
+     *      to return just the base URI if it is implied to not be a directory.
+     *
+     *      This is to help with ERC721 contracts in which the same token URI 
+     *      is desired for each token, such as when the tokenURI is 'unrevealed'.
+     */
+    function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
+        if (!_exists(tokenId)) revert URIQueryForNonexistentToken();
+        
+        string memory baseURI = _baseURI();
+        
+        // Exit early if the baseURI is empty.
+        if (bytes(baseURI).length == 0) {
+            return '';
+        }
+
+        // Check if the last character in baseURI is a slash.
+        if  (bytes(baseURI)[bytes(baseURI).length - 1] != bytes("/")[0]) {
+            return baseURI;
+        }
+
+        return string(abi.encodePacked(baseURI, _toString(tokenId)));
     }
 
     /**

--- a/test/ERC721ContractMetadata.spec.ts
+++ b/test/ERC721ContractMetadata.spec.ts
@@ -153,4 +153,31 @@ describe(`ERC721ContractMetadata (v${VERSION})`, function () {
     // 0x2a55205a is interface id for EIP-2981
     expect(await token.supportsInterface("0x2a55205a")).to.equal(true);
   });
+
+  it("Should return the correct tokenURI based on baseURI's last character", async () => {
+    // If the baseURI ends with "/" then the tokenURI should be baseURI + tokenId
+    await expect(
+      token.connect(owner).setBaseURI("http://example.com/")
+    ).to.emit(token, "BatchMetadataUpdate");
+
+    await whileImpersonating(
+      seadrop.address,
+      provider,
+      async (impersonatedSigner) => {
+        await token.connect(impersonatedSigner).mintSeaDrop(owner.address, 2);
+      }
+    );
+    expect(await token.baseURI()).to.equal("http://example.com/");
+    expect(await token.tokenURI(1)).to.equal("http://example.com/1");
+    expect(await token.tokenURI(2)).to.equal("http://example.com/2");
+
+    // If the baseURI does not end with "/" then the tokenURI should just be baseURI
+    await expect(
+      token.connect(owner).setBaseURI("http://example.com")
+    ).to.emit(token, "BatchMetadataUpdate");
+
+    expect(await token.baseURI()).to.equal("http://example.com");
+    expect(await token.tokenURI(1)).to.equal("http://example.com");
+    expect(await token.tokenURI(2)).to.equal("http://example.com");
+  });
 });


### PR DESCRIPTION
This PR overrides the default `tokenURI()` implementation in ERC721A to return just the `baseURI` for a token contract if the URI does not end with a `/`.

## Motivation
At the moment it is difficult to set up Drops where all the tokenURIs need to be the same (such as for Open Editions or for pre-revealed Drops) as they require that token contract owners upload one file per token, which often end up being the same. 

## Solution
This change will treat any `baseURI` that does not end with a `/` as a 'single file' instead of a directory and return **just** the `baseURI`. Any `baseURI` that ends with `/` will function normally and return the `baseURI + tokenID`


## Note
IDK what I'm doing. Any and all feedback on improving both the implementation and the tests are welcome :) 