### PR TITLE
Add new tokenURI() to upgradeable and proxy contracts

### DIFF
--- a/src-upgradeable/src/ERC721SeaDropUpgradeable.sol
+++ b/src-upgradeable/src/ERC721SeaDropUpgradeable.sol
@@ -190,6 +190,37 @@ contract ERC721SeaDropUpgradeable is
     }
 
     /**
+     * @dev Overrides the `tokenURI()` function from ERC721A
+     *      to return just the base URI if it is implied to not be a directory.
+     *
+     *      This is to help with ERC721 contracts in which the same token URI
+     *      is desired for each token, such as when the tokenURI is 'unrevealed'.
+     */
+    function tokenURI(uint256 tokenId)
+        public
+        view
+        virtual
+        override
+        returns (string memory)
+    {
+        if (!_exists(tokenId)) revert URIQueryForNonexistentToken();
+
+        string memory baseURI = _baseURI();
+
+        // Exit early if the baseURI is empty.
+        if (bytes(baseURI).length == 0) {
+            return "";
+        }
+
+        // Check if the last character in baseURI is a slash.
+        if (bytes(baseURI)[bytes(baseURI).length - 1] != bytes("/")[0]) {
+            return baseURI;
+        }
+
+        return string(abi.encodePacked(baseURI, _toString(tokenId)));
+    }
+
+    /**
      * @notice Mint tokens, restricted to the SeaDrop contract.
      *
      * @dev    NOTE: If a token registers itself with multiple SeaDrop

--- a/src/clones/ERC721SeaDropCloneable.sol
+++ b/src/clones/ERC721SeaDropCloneable.sol
@@ -150,6 +150,37 @@ contract ERC721SeaDropCloneable is
     }
 
     /**
+     * @dev Overrides the `tokenURI()` function from ERC721A
+     *      to return just the base URI if it is implied to not be a directory.
+     *
+     *      This is to help with ERC721 contracts in which the same token URI
+     *      is desired for each token, such as when the tokenURI is 'unrevealed'.
+     */
+    function tokenURI(uint256 tokenId)
+        public
+        view
+        virtual
+        override
+        returns (string memory)
+    {
+        if (!_exists(tokenId)) revert URIQueryForNonexistentToken();
+
+        string memory baseURI = _baseURI();
+
+        // Exit early if the baseURI is empty.
+        if (bytes(baseURI).length == 0) {
+            return "";
+        }
+
+        // Check if the last character in baseURI is a slash.
+        if (bytes(baseURI)[bytes(baseURI).length - 1] != bytes("/")[0]) {
+            return baseURI;
+        }
+
+        return string(abi.encodePacked(baseURI, _toString(tokenId)));
+    }
+
+    /**
      * @notice Mint tokens, restricted to the SeaDrop contract.
      *
      * @dev    NOTE: If a token registers itself with multiple SeaDrop

--- a/test/foundry/ERC721SeaDropCloneFactory.t.sol
+++ b/test/foundry/ERC721SeaDropCloneFactory.t.sol
@@ -68,6 +68,23 @@ contract ERC721SeaDropCloneFactoryTest is Test {
         );
         assertEq(token.totalSupply(), 1);
         assertEq(token.ownerOf(1), address(this));
+
+        assertEq(token.tokenURI(1), "", "tokenURI should be blank at first");
+        assertEq(token.baseURI(), "", "baseURI should be blank at first");
+
+        token.setBaseURI("https://example.com");
+        assertEq(
+            token.tokenURI(1),
+            token.baseURI(),
+            "tokenURI just the baseURI"
+        );
+
+        token.setBaseURI("https://example.com/");
+        assertEq(
+            token.tokenURI(1),
+            string(abi.encodePacked(token.baseURI(), "1")),
+            "tokenURI the baseURI + tokenID"
+        );
     }
 
     function testClone_Reinitialize() public {


### PR DESCRIPTION
Add the same `tokenURI()` implementation to the upgradable and proxy contracts

## Motivation
Can use the same pattern in these contracts as well

## Solution
Same implementation