### PR TITLE
Solidity version pragma updated to accept newer compilers

### DIFF
--- a/script/DeployAndConfigureExampleToken.s.sol
+++ b/script/DeployAndConfigureExampleToken.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import "forge-std/Script.sol";
 

--- a/src-upgradeable/lib-upgradeable/solmate/src/test/Auth.t.sol
+++ b/src-upgradeable/lib-upgradeable/solmate/src/test/Auth.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import {DSTestPlus} from "./utils/DSTestPlus.sol";
 import {MockAuthChild} from "./utils/mocks/MockAuthChild.sol";

--- a/src-upgradeable/lib-upgradeable/solmate/src/test/Bytes32AddressLib.t.sol
+++ b/src-upgradeable/lib-upgradeable/solmate/src/test/Bytes32AddressLib.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import {DSTestPlus} from "./utils/DSTestPlus.sol";
 

--- a/src-upgradeable/lib-upgradeable/solmate/src/test/CREATE3.t.sol
+++ b/src-upgradeable/lib-upgradeable/solmate/src/test/CREATE3.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import {WETH} from "../tokens/WETH.sol";
 import {DSTestPlus} from "./utils/DSTestPlus.sol";

--- a/src-upgradeable/lib-upgradeable/solmate/src/test/DSTestPlus.t.sol
+++ b/src-upgradeable/lib-upgradeable/solmate/src/test/DSTestPlus.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import {DSTestPlus} from "./utils/DSTestPlus.sol";
 

--- a/src-upgradeable/lib-upgradeable/solmate/src/test/ERC1155.t.sol
+++ b/src-upgradeable/lib-upgradeable/solmate/src/test/ERC1155.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import {DSTestPlus} from "./utils/DSTestPlus.sol";
 import {DSInvariantTest} from "./utils/DSInvariantTest.sol";

--- a/src-upgradeable/lib-upgradeable/solmate/src/test/ERC20.t.sol
+++ b/src-upgradeable/lib-upgradeable/solmate/src/test/ERC20.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import {DSTestPlus} from "./utils/DSTestPlus.sol";
 import {DSInvariantTest} from "./utils/DSInvariantTest.sol";

--- a/src-upgradeable/lib-upgradeable/solmate/src/test/ERC4626.t.sol
+++ b/src-upgradeable/lib-upgradeable/solmate/src/test/ERC4626.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import {DSTestPlus} from "./utils/DSTestPlus.sol";
 

--- a/src-upgradeable/lib-upgradeable/solmate/src/test/ERC721.t.sol
+++ b/src-upgradeable/lib-upgradeable/solmate/src/test/ERC721.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import {DSTestPlus} from "./utils/DSTestPlus.sol";
 import {DSInvariantTest} from "./utils/DSInvariantTest.sol";

--- a/src-upgradeable/lib-upgradeable/solmate/src/test/FixedPointMathLib.t.sol
+++ b/src-upgradeable/lib-upgradeable/solmate/src/test/FixedPointMathLib.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import {DSTestPlus} from "./utils/DSTestPlus.sol";
 

--- a/src-upgradeable/lib-upgradeable/solmate/src/test/MultiRolesAuthority.t.sol
+++ b/src-upgradeable/lib-upgradeable/solmate/src/test/MultiRolesAuthority.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import {DSTestPlus} from "./utils/DSTestPlus.sol";
 import {MockAuthority} from "./utils/mocks/MockAuthority.sol";

--- a/src-upgradeable/lib-upgradeable/solmate/src/test/Owned.t.sol
+++ b/src-upgradeable/lib-upgradeable/solmate/src/test/Owned.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import {DSTestPlus} from "./utils/DSTestPlus.sol";
 import {MockOwned} from "./utils/mocks/MockOwned.sol";

--- a/src-upgradeable/lib-upgradeable/solmate/src/test/ReentrancyGuard.t.sol
+++ b/src-upgradeable/lib-upgradeable/solmate/src/test/ReentrancyGuard.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import {DSTestPlus} from "./utils/DSTestPlus.sol";
 

--- a/src-upgradeable/lib-upgradeable/solmate/src/test/RolesAuthority.t.sol
+++ b/src-upgradeable/lib-upgradeable/solmate/src/test/RolesAuthority.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import {DSTestPlus} from "./utils/DSTestPlus.sol";
 import {MockAuthority} from "./utils/mocks/MockAuthority.sol";

--- a/src-upgradeable/lib-upgradeable/solmate/src/test/SSTORE2.t.sol
+++ b/src-upgradeable/lib-upgradeable/solmate/src/test/SSTORE2.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import {DSTestPlus} from "./utils/DSTestPlus.sol";
 

--- a/src-upgradeable/lib-upgradeable/solmate/src/test/SafeCastLib.t.sol
+++ b/src-upgradeable/lib-upgradeable/solmate/src/test/SafeCastLib.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import {DSTestPlus} from "./utils/DSTestPlus.sol";
 

--- a/src-upgradeable/lib-upgradeable/solmate/src/test/SafeTransferLib.t.sol
+++ b/src-upgradeable/lib-upgradeable/solmate/src/test/SafeTransferLib.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import {MockERC20} from "./utils/mocks/MockERC20.sol";
 import {RevertingToken} from "./utils/weird-tokens/RevertingToken.sol";

--- a/src-upgradeable/lib-upgradeable/solmate/src/test/WETH.t.sol
+++ b/src-upgradeable/lib-upgradeable/solmate/src/test/WETH.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import {DSTestPlus} from "./utils/DSTestPlus.sol";
 import {DSInvariantTest} from "./utils/DSInvariantTest.sol";

--- a/src-upgradeable/src/ERC721ContractMetadataUpgradeable.sol
+++ b/src-upgradeable/src/ERC721ContractMetadataUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import {
     ISeaDropTokenContractMetadataUpgradeable

--- a/src-upgradeable/src/ERC721PartnerSeaDropUpgradeable.sol
+++ b/src-upgradeable/src/ERC721PartnerSeaDropUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import { ERC721SeaDropUpgradeable } from "./ERC721SeaDropUpgradeable.sol";
 

--- a/src-upgradeable/src/ERC721SeaDropUpgradeable.sol
+++ b/src-upgradeable/src/ERC721SeaDropUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import {
     ERC721ContractMetadataUpgradeable,

--- a/src-upgradeable/src/ExampleToken.sol
+++ b/src-upgradeable/src/ExampleToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import {
     ERC721PartnerSeaDropUpgradeable

--- a/src-upgradeable/src/extensions/ERC721PartnerSeaDropBurnableUpgradeable.sol
+++ b/src-upgradeable/src/extensions/ERC721PartnerSeaDropBurnableUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import {
     ERC721PartnerSeaDropUpgradeable

--- a/src-upgradeable/src/extensions/ERC721PartnerSeaDropRandomOffsetStorage.sol
+++ b/src-upgradeable/src/extensions/ERC721PartnerSeaDropRandomOffsetStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import {
     ERC721PartnerSeaDropRandomOffsetUpgradeable

--- a/src-upgradeable/src/extensions/ERC721PartnerSeaDropRandomOffsetUpgradeable.sol
+++ b/src-upgradeable/src/extensions/ERC721PartnerSeaDropRandomOffsetUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import {
     ERC721PartnerSeaDropUpgradeable

--- a/src-upgradeable/src/interfaces/INonFungibleSeaDropTokenUpgradeable.sol
+++ b/src-upgradeable/src/interfaces/INonFungibleSeaDropTokenUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import {
     ISeaDropTokenContractMetadataUpgradeable

--- a/src-upgradeable/src/interfaces/ISeaDropTokenContractMetadataUpgradeable.sol
+++ b/src-upgradeable/src/interfaces/ISeaDropTokenContractMetadataUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import {
     IERC2981Upgradeable

--- a/src-upgradeable/src/interfaces/ISeaDropUpgradeable.sol
+++ b/src-upgradeable/src/interfaces/ISeaDropUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import {
     AllowListData,

--- a/src-upgradeable/src/lib/ERC721SeaDropStructsErrorsAndEventsUpgradeable.sol
+++ b/src-upgradeable/src/lib/ERC721SeaDropStructsErrorsAndEventsUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import {
   AllowListData,

--- a/src-upgradeable/src/lib/SeaDropErrorsAndEventsUpgradeable.sol
+++ b/src-upgradeable/src/lib/SeaDropErrorsAndEventsUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import { PublicDrop, TokenGatedDropStage, SignedMintValidationParams } from "./SeaDropStructsUpgradeable.sol";
 

--- a/src-upgradeable/src/lib/SeaDropStructsUpgradeable.sol
+++ b/src-upgradeable/src/lib/SeaDropStructsUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 /**
  * @notice A struct defining public drop data.

--- a/src/ERC721ContractMetadata.sol
+++ b/src/ERC721ContractMetadata.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import {
     ISeaDropTokenContractMetadata

--- a/src/ERC721PartnerSeaDrop.sol
+++ b/src/ERC721PartnerSeaDrop.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import { ERC721SeaDrop } from "./ERC721SeaDrop.sol";
 

--- a/src/ERC721SeaDrop.sol
+++ b/src/ERC721SeaDrop.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import {
     ERC721ContractMetadata,

--- a/src/SeaDrop.sol
+++ b/src/SeaDrop.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import { ISeaDrop } from "./interfaces/ISeaDrop.sol";
 

--- a/src/clones/ERC721ContractMetadataCloneable.sol
+++ b/src/clones/ERC721ContractMetadataCloneable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import {
     ISeaDropTokenContractMetadata

--- a/src/clones/ERC721SeaDropCloneFactory.sol
+++ b/src/clones/ERC721SeaDropCloneFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import { ERC721SeaDropCloneable } from "./ERC721SeaDropCloneable.sol";
 

--- a/src/clones/ERC721SeaDropCloneable.sol
+++ b/src/clones/ERC721SeaDropCloneable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import {
     ERC721ContractMetadataCloneable,

--- a/src/extensions/ERC721PartnerSeaDropBurnable.sol
+++ b/src/extensions/ERC721PartnerSeaDropBurnable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import { ERC721PartnerSeaDrop } from "../ERC721PartnerSeaDrop.sol";
 

--- a/src/extensions/ERC721PartnerSeaDropRandomOffset.sol
+++ b/src/extensions/ERC721PartnerSeaDropRandomOffset.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import { ERC721PartnerSeaDrop } from "../ERC721PartnerSeaDrop.sol";
 

--- a/src/extensions/ERC721SeaDropBurnable.sol
+++ b/src/extensions/ERC721SeaDropBurnable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import { ERC721SeaDrop } from "../ERC721SeaDrop.sol";
 

--- a/src/extensions/ERC721SeaDropRandomOffset.sol
+++ b/src/extensions/ERC721SeaDropRandomOffset.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import { ERC721SeaDrop } from "../ERC721SeaDrop.sol";
 

--- a/src/interfaces/INonFungibleSeaDropToken.sol
+++ b/src/interfaces/INonFungibleSeaDropToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import {
     ISeaDropTokenContractMetadata

--- a/src/interfaces/ISeaDrop.sol
+++ b/src/interfaces/ISeaDrop.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import {
     AllowListData,

--- a/src/interfaces/ISeaDropTokenContractMetadata.sol
+++ b/src/interfaces/ISeaDropTokenContractMetadata.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import { IERC2981 } from "openzeppelin-contracts/interfaces/IERC2981.sol";
 

--- a/src/lib/ERC721SeaDropStructsErrorsAndEvents.sol
+++ b/src/lib/ERC721SeaDropStructsErrorsAndEvents.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import {
   AllowListData,

--- a/src/lib/SeaDropErrorsAndEvents.sol
+++ b/src/lib/SeaDropErrorsAndEvents.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import { PublicDrop, TokenGatedDropStage, SignedMintValidationParams } from "./SeaDropStructs.sol";
 

--- a/src/lib/SeaDropStructs.sol
+++ b/src/lib/SeaDropStructs.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 /**
  * @notice A struct defining public drop data.

--- a/src/shim/Shim.sol
+++ b/src/shim/Shim.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 /**
  * @dev HardHat doesn't support multiple source folders; so import everything

--- a/src/test/MaliciousRecipient.sol
+++ b/src/test/MaliciousRecipient.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import { SeaDrop } from "../SeaDrop.sol";
 

--- a/src/test/TestERC721.sol
+++ b/src/test/TestERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Unlicense
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import { ERC721 } from "solmate/tokens/ERC721.sol";
 

--- a/test/foundry/SeaDrop-mintAllowList.t.sol
+++ b/test/foundry/SeaDrop-mintAllowList.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import { TestHelper } from "test/foundry/utils/TestHelper.sol";
 

--- a/test/foundry/SeaDrop-mintAllowedTokenHolder.t.sol
+++ b/test/foundry/SeaDrop-mintAllowedTokenHolder.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import { TestHelper } from "test/foundry/utils/TestHelper.sol";
 

--- a/test/foundry/SeaDrop-mintPublic.t.sol
+++ b/test/foundry/SeaDrop-mintPublic.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import { TestHelper } from "test/foundry/utils/TestHelper.sol";
 

--- a/test/foundry/SeaDrop-mintSigned.t.sol
+++ b/test/foundry/SeaDrop-mintSigned.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import { TestHelper } from "test/foundry/utils/TestHelper.sol";
 

--- a/test/foundry/SeaDrop.t.sol
+++ b/test/foundry/SeaDrop.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import { TestHelper } from "test/foundry/utils/TestHelper.sol";
 

--- a/test/foundry/SeaDropSnapshot.t.sol
+++ b/test/foundry/SeaDropSnapshot.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import { TestHelper } from "test/foundry/utils/TestHelper.sol";
 

--- a/test/foundry/utils/TestHelper.sol
+++ b/test/foundry/utils/TestHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import "forge-std/Test.sol";
 


### PR DESCRIPTION
## Motivation

Some of the Solidity files in the repository are annotated with a fixed version pragma (0.8.17 or 0.8.15) unallowing to be imported and compiled with projects that use newer Solidity compilers (e.g. 0.8.19).

## Solution

The files containing a fixed version pragma were modified to allow compilation with newer compiler versions, just by adding the `^` prefix on the version [as Solidity documentation explains](https://docs.soliditylang.org/en/v0.8.19/layout-of-source-files.html#version-pragma).
