### PR TITLE
Make SeaDropRandomOffset trustless

### DIFF
--- a/src/extensions/ERC721PartnerSeaDropRandomOffset.sol
+++ b/src/extensions/ERC721PartnerSeaDropRandomOffset.sol
@@ -8,6 +8,8 @@ import { ERC721PartnerSeaDrop } from "../ERC721PartnerSeaDrop.sol";
  * @author James Wenzel (emo.eth)
  * @author Ryan Ghods (ralxz.eth)
  * @author Stephan Min (stephanm.eth)
+ * @author Michael Cohen (notmichael.eth)
+ * @author Ryan Meyers (strangeruff.eth)
  * @notice ERC721PartnerSeaDropRandomOffset is a token contract that extends
  *         ERC721PartnerSeaDrop to apply a randomOffset to the tokenURI,
  *         to enable fair metadata reveals.
@@ -16,10 +18,12 @@ contract ERC721PartnerSeaDropRandomOffset is ERC721PartnerSeaDrop {
     /// @notice The random offset, between 1 and the MAX_SUPPLY at the time of
     ///         being set.
     uint256 public randomOffset;
+    uint256 private _revealBlock = 1;
 
     /// @notice If the collection has been revealed and the randomOffset has
     ///         been set. 1=False, 2=True.
     uint256 public revealed = _REVEALED_FALSE;
+    uint256 public revealAllowed = _REVEALED_FALSE;
 
     /// @dev For gas efficiency, uint is used instead of bool for revealed.
     uint256 private constant _REVEALED_FALSE = 1;
@@ -31,6 +35,9 @@ contract ERC721PartnerSeaDropRandomOffset is ERC721PartnerSeaDrop {
     /// @notice Revert when setting the randomOffset if the collection is
     ///         not yet fully minted.
     error NotFullyMinted();
+
+    /// @notice Revert when reveal is not yet allowed
+    error RevealNotAllowed();
 
     /**
      * @notice Deploy the token contract with its name, symbol,
@@ -44,16 +51,43 @@ contract ERC721PartnerSeaDropRandomOffset is ERC721PartnerSeaDrop {
     ) ERC721PartnerSeaDrop(name, symbol, administrator, allowedSeaDrop) {}
 
     /**
-     * @notice Set the random offset, for a fair metadata reveal. Only callable
-     *         by the owner one time when the total number of minted tokens
-     *         equals the max supply. Should be called immediately before
-     *         reveal.
+     * @notice Allow the reveal method to be called
+     *         May be called in the constructor if desired to reveal
+     *         any time after max supply is reached.
+     */
+    function _allowReveal() internal {
+        revealAllowed = _REVEALED_TRUE;
+    }
+
+    /**
+     * @notice  External function for contract owner to allow reveal.
+     *          If the totalMinted has reached maxSupply, go ahead and prime
+     *          the reveal block.
+     */
+    function allowReveal() external virtual onlyOwner {
+        _allowReveal();
+        if (_totalMinted() >= _maxSupply) {
+            setRandomOffset();
+        }
+    }
+
+    /**
+     * @notice Set the random offset, for a fair metadata reveal.
+     *         Must be called once to prime the reveal block, then again
+     *         (at least 10 and less than 50 minutes later) to reveal.
+     *         Priming prevents even the owner from determining the offset.
+     *         May be overridden (using super) to extend or allow only the owner to reveal.
+     *         Should be called immediately before reveal.
      */
     // solhint-disable-next-line comprehensive-interface
-    function setRandomOffset() external onlyOwner {
+    function setRandomOffset() public virtual {
         // Revert setting the offset if already revealed.
         if (revealed == _REVEALED_TRUE) {
             revert AlreadyRevealed();
+        }
+
+        if (revealAllowed == _REVEALED_FALSE) {
+            revert RevealNotAllowed();
         }
 
         // Put maxSupply on the stack, since reading a state variable
@@ -65,16 +99,30 @@ contract ERC721PartnerSeaDropRandomOffset is ERC721PartnerSeaDrop {
             revert NotFullyMinted();
         }
 
-        // block.difficulty returns PREVRANDAO on Ethereum post-merge
-        // NOTE: do not use this on other chains
-        // randomOffset returns between 1 and MAX_SUPPLY
-        randomOffset =
-            (uint256(keccak256(abi.encode(block.difficulty))) %
-                (maxSupply - 1)) +
-            1;
+        uint256 revealBlock = _revealBlock;
 
-        // Set revealed to true.
-        revealed = _REVEALED_TRUE;
+        // Lookback for block hashes only available for the last 256 blocks
+        if (block.number > revealBlock + 255) {
+            _revealBlock = block.number + 50;
+        } else if (block.number > revealBlock) {
+            // block.difficulty returns PREVRANDAO on Ethereum post-merge
+            // NOTE: do not use this on other chains
+            // randomOffset returns between 1 and MAX_SUPPLY
+            randomOffset =
+                (uint256(
+                    keccak256(
+                        abi.encode(blockhash(revealBlock), block.difficulty)
+                    )
+                ) % (maxSupply - 1)) +
+                1;
+
+            // Set revealed to true.
+            revealed = _REVEALED_TRUE;
+
+            // Emit the metadata update event for OpenSea
+            uint256 startTokenId = _startTokenId();
+            emit BatchMetadataUpdate(startTokenId, startTokenId + maxSupply);
+        }
     }
 
     /**

--- a/test/ERC721PartnerSeaDropRandomOffset.spec.ts
+++ b/test/ERC721PartnerSeaDropRandomOffset.spec.ts
@@ -28,6 +28,7 @@ describe(`ERC721PartnerSeaDropRandomOffset (v${VERSION})`, function () {
   });
 
   before(async () => {
+    await network.provider.send("hardhat_mine", ["0x15b3"]);
     // Set the wallets
     owner = new ethers.Wallet(randomHex(32), provider);
     admin = new ethers.Wallet(randomHex(32), provider);
@@ -58,12 +59,67 @@ describe(`ERC721PartnerSeaDropRandomOffset (v${VERSION})`, function () {
     );
   });
 
-  it("Should only let the owner call setRandomOffset once the max supply is reached", async () => {
+  it("Should only let the owner call allowReveal", async () => {
     await token.setMaxSupply(100);
 
-    await expect(token.connect(admin).setRandomOffset()).to.be.revertedWith(
+    await expect(token.connect(admin).allowReveal()).to.be.revertedWith(
       "OnlyOwner()"
     );
+
+    // Mint to the max supply.
+    await whileImpersonating(
+      seadrop.address,
+      provider,
+      async (impersonatedSigner) => {
+        await token
+          .connect(impersonatedSigner)
+          .mintSeaDrop(minter.address, 100);
+      }
+    );
+
+    await expect(token.connect(admin).allowReveal()).to.be.revertedWith(
+      "OnlyOwner()"
+    );
+
+    expect(await token.randomOffset()).to.equal(ethers.constants.Zero);
+
+    await token.connect(owner).allowReveal();
+
+    expect(await token.randomOffset()).to.equal(ethers.constants.Zero);
+
+    await network.provider.send("hardhat_mine", ["0x37"]);
+
+    await token.connect(owner).setRandomOffset();
+
+    expect(await token.randomOffset()).to.not.equal(ethers.constants.Zero);
+
+    await expect(token.connect(owner).setRandomOffset()).to.be.revertedWith(
+      "AlreadyRevealed()"
+    );
+
+    expect(await token.randomOffset()).to.not.equal(ethers.constants.Zero);
+  });
+
+  it("Should only allow setRandomOffset once the max supply is reached", async () => {
+    await token.setMaxSupply(100);
+
+    await expect(token.connect(minter).setRandomOffset()).to.be.revertedWith(
+      "RevealNotAllowed()"
+    );
+
+    await expect(token.connect(owner).setRandomOffset()).to.be.revertedWith(
+      "RevealNotAllowed()"
+    );
+
+    expect(await token.randomOffset()).to.equal(ethers.constants.Zero);
+
+    await token.connect(owner).allowReveal();
+
+    await expect(token.connect(minter).setRandomOffset()).to.be.revertedWith(
+      "NotFullyMinted()"
+    );
+
+    expect(await token.randomOffset()).to.equal(ethers.constants.Zero);
 
     await expect(token.connect(owner).setRandomOffset()).to.be.revertedWith(
       "NotFullyMinted()"
@@ -80,23 +136,17 @@ describe(`ERC721PartnerSeaDropRandomOffset (v${VERSION})`, function () {
       }
     );
 
-    await expect(token.connect(admin).setRandomOffset()).to.be.revertedWith(
-      "OnlyOwner()"
-    );
-
-    expect(await token.randomOffset()).to.equal(ethers.constants.Zero);
-
+    await token.connect(minter).setRandomOffset();
+    await network.provider.send("hardhat_mine", ["0x37"]);
     await token.connect(owner).setRandomOffset();
-
-    await expect(token.connect(owner).setRandomOffset()).to.be.revertedWith(
-      "AlreadyRevealed()"
-    );
 
     expect(await token.randomOffset()).to.not.equal(ethers.constants.Zero);
   });
 
   it("Should return the tokenURI correctly offset by randomOffset", async () => {
     await token.setMaxSupply(100);
+
+    await token.connect(owner).allowReveal();
 
     await expect(token.tokenURI(1)).to.be.revertedWith(
       "URIQueryForNonexistentToken()"
@@ -119,6 +169,8 @@ describe(`ERC721PartnerSeaDropRandomOffset (v${VERSION})`, function () {
 
     expect(await token.tokenURI(1)).to.equal("http://example.com/");
 
+    await token.connect(owner).setRandomOffset();
+    await network.provider.send("hardhat_mine", ["0x37"]);
     await token.connect(owner).setRandomOffset();
 
     const randomOffset = (await token.randomOffset()).toNumber();


### PR DESCRIPTION
## Motivation

The random offset extensions are helpful for obfuscating pre-uploaded token metadata, but the nature of the implementation prevents it from being truly trustless. The contract owner could, in theory, reveal using a smart contract that reverted unless a desired offset was achieved. 

## Solution

To avoid this, a commit/reveal mechanism can be implemented: the first time the function is called, it sets the reveal block to be 50 blocks in the future (post-merge, MEV validators can actually control multiple blocks, but 50 is far enough out to make that extremely unlikely) - so essentially the reveal block is primed with the first call, then revealed with the next (~10+ minutes later, no more than 50 minutes in the future). The method is also opened to anyone (which would make automating the process much more secure) but requires that an `_allowReveal()` method be called - which could be either in the constructor or manually by the onlyOwner `allowReveal()` public function.

Additionally, the `BatchMetadataUpdate` event is triggered upon reveal so that OS will automatically refresh all the tokens.

*Note: I just updated the hardhat tests, as I'm not super familiar with foundry yet. 
