### PR TITLE
change memory to calldata to save gas

### DIFF
--- a/src/ERC721PartnerSeaDrop.sol
+++ b/src/ERC721PartnerSeaDrop.sol
@@ -275,7 +275,7 @@ contract ERC721PartnerSeaDrop is ERC721SeaDrop, TwoStepAdministered {
     function updateSignedMintValidationParams(
         address seaDropImpl,
         address signer,
-        SignedMintValidationParams memory signedMintValidationParams
+        SignedMintValidationParams calldata signedMintValidationParams
     ) external virtual override onlyOwnerOrAdministrator {
         // Ensure the SeaDrop is allowed.
         _onlyAllowedSeaDrop(seaDropImpl);

--- a/src/ERC721SeaDrop.sol
+++ b/src/ERC721SeaDrop.sol
@@ -385,7 +385,7 @@ contract ERC721SeaDrop is
     function updateSignedMintValidationParams(
         address seaDropImpl,
         address signer,
-        SignedMintValidationParams memory signedMintValidationParams
+        SignedMintValidationParams calldata signedMintValidationParams
     ) external virtual override {
         // Ensure the sender is only the owner or contract itself.
         _onlyOwnerOrSelf();


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Calldata is the cheapest location to save an input parameter.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->
Changing the data location of function parameters from memory to calldata can save much gas.
In the following example, test4 saves about 955 units of gas.

```
    function test3(uint256[] memory amounts) public {
        uint256 amount = amounts[0];
    }

    function test4(uint256[] calldata amounts) public {
        uint256 amount = amounts[0];
    }
```

## Solution
Change the the data location of function parameters which are not modified in the function to calldata.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
