### PR TITLE
move variable initialization out from loop to save gas

### DIFF
--- a/src/SeaDrop.sol
+++ b/src/SeaDrop.sol
@@ -548,9 +548,11 @@ contract SeaDrop is ISeaDrop, ReentrancyGuard {
 
         // Iterate through each allowedNftTokenId
         // to ensure it is not already redeemed.
+        uint256 tokenId;
+        mapping(uint256 => bool) storage redeemedTokenIds;
         for (uint256 i = 0; i < mintQuantity; ) {
             // Put the tokenId on the stack.
-            uint256 tokenId = mintParams.allowedNftTokenIds[i];
+            tokenId = mintParams.allowedNftTokenIds[i];
 
             // Check that the minter is the owner of the allowedNftTokenId.
             if (IERC721(allowedNftToken).ownerOf(tokenId) != minter) {
@@ -562,8 +564,7 @@ contract SeaDrop is ISeaDrop, ReentrancyGuard {
             }
 
             // Cache the storage pointer for cheaper access.
-            mapping(uint256 => bool)
-                storage redeemedTokenIds = _tokenGatedRedeemed[nftContract][
+            redeemedTokenIds = _tokenGatedRedeemed[nftContract][
                     allowedNftToken
                 ];
 


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Initializing variables before the loop instead of inside the loop saves gas. In the example below, function test4 consumes 553 units less gas than function test3 when the length of ```arr``` is 100.
```
    function test3(uint256[] memory arr) public {
        for(uint256 i = 0; i < arr.length; i++) {
            uint256 a = arr[i];
        }
    }

    function test4(uint256[] memory arr) public {
        uint256 a;
        for(uint256 i = 0; i < arr.length; i++) {
            a = arr[i];
        }
    }
```
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution
Moving variable initialization out from loop to save gas.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
