### PR TITLE
declaring return variable in function's declaration to save gas

### DIFF
--- a/src/extensions/ERC721SeaDropRandomOffset.sol
+++ b/src/extensions/ERC721SeaDropRandomOffset.sol
@@ -87,13 +87,13 @@ contract ERC721SeaDropRandomOffset is ERC721SeaDrop {
         public
         view
         override
-        returns (string memory)
+        returns (string memory base)
     {
         if (!_exists(tokenId)) {
             revert URIQueryForNonexistentToken();
         }
 
-        string memory base = _baseURI();
+        base = _baseURI();
         if (bytes(base).length == 0) {
             // If there is no baseURI set, return an empty string.
             return "";


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->


## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->
If returning a local variable, solidity will create a local variable and copy its value to the stack variable that represents the return variable. This consumes more gas than declaring return variable in function's declaration.

## Solution
Instead of creating a local variable and return it, declare return variable in function's declaration.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
