### PR TITLE
Update .gitmodules to use https on all repos

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,10 +19,10 @@
 	url = https://github.com/openzeppelin/openzeppelin-contracts
 [submodule "lib/openzeppelin-contracts-upgradeable"]
 	path = lib/openzeppelin-contracts-upgradeable
-	url = git@github.com:OpenZeppelin/openzeppelin-contracts-upgradeable.git
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable
 [submodule "lib/ERC721A-Upgradeable"]
 	path = lib/ERC721A-Upgradeable
-	url = git@github.com:chiru-labs/ERC721A-Upgradeable.git
+	url = https://github.com/chiru-labs/ERC721A-Upgradeable
 [submodule "lib/ds-test"]
 	path = lib/ds-test
 	url = https://github.com/dapphub/ds-test


### PR DESCRIPTION
Quality of life improvement: update submodules urls to https to avoid git errors

## Motivation

After cloning the repo and attempting to update the modules you get "The authenticity of host 'github.com (---)' can't be established" which stems from the 3 submodules that were not using https.


## Solution


Updated those submodules urls to include https. '''git module update''' runs smoothly now

