### PR TITLE
Update actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     name: Run Linters
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -33,7 +33,7 @@ jobs:
     name: Run Hardhat Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -52,7 +52,7 @@ jobs:
   #   name: Run Hardhat Upgradeable Tests
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v3
+  #     - uses: actions/checkout@v4
   #       with:
   #         submodules: recursive
   #
@@ -70,7 +70,7 @@ jobs:
     name: Run Hardhat Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -95,7 +95,7 @@ jobs:
     name: Run Forge Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -117,7 +117,7 @@ jobs:
     name: Run Forge Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 


### PR DESCRIPTION
Upgrade the `actions/checkout` GitHub Action from version 3 to version 4 to leverage the latest improvements, bug fixes, and enhanced performance. Version 4 offers better support for modern Git features and improved security.

[actions/checkout releases](https://github.com/actions/checkout/releases)