### PR TITLE
Fix Typos in Comments for ERC721A Contracts

### DIFF
--- a/src-upgradeable/lib-upgradeable/utility-contracts/test/ERC721A.sol
+++ b/src-upgradeable/lib-upgradeable/utility-contracts/test/ERC721A.sol
@@ -668,7 +668,7 @@ contract ERC721A is IERC721A {
 
             // Updates:
             // - `address` to the next owner.
-            // - `startTimestamp` to the timestamp of transfering.
+            // - `startTimestamp` to the timestamp of transferring.
             // - `burned` to `false`.
             // - `nextInitialized` to `true`.
             _packedOwnerships[tokenId] = _packOwnershipData(

--- a/src/clones/ERC721ACloneable.sol
+++ b/src/clones/ERC721ACloneable.sol
@@ -409,7 +409,7 @@ contract ERC721ACloneable is IERC721A, Initializable {
                         // Invariant:
                         // There will always be an initialized ownership slot
                         // (i.e. `ownership.addr != address(0) && ownership.burned == false`)
-                        // before an unintialized ownership slot
+                        // before an uninitialized ownership slot
                         // (i.e. `ownership.addr == address(0) && ownership.burned == false`)
                         // Hence, `curr` will not underflow.
                         //


### PR DESCRIPTION


Description:  
This pull request corrects minor spelling mistakes in the comments of two Solidity files:

- In `test/ERC721A.sol`, the word "transfering" has been corrected to "transferring".
- In `ERC721ACloneable.sol`, the word "uninitialized" has been corrected.

These changes improve code readability and maintain consistency in documentation. No functional code has been modified.